### PR TITLE
Change all

### DIFF
--- a/src/lib/components/recal/Top.svelte
+++ b/src/lib/components/recal/Top.svelte
@@ -67,7 +67,7 @@ $: cssVarStyles = calculateCssVars("0", $calColors);
 </script>
 
 <div style={cssVarStyles} id="parent"
-class="h-20 px-1 overflow-clip  text-zinc-900
+class="h-20 px-1 overflow-clip text-zinc-900
 dark:text-zinc-100 text-sm">
     <div class="justify-between flex">
         <div class="bg-zinc-100 dark:bg-zinc-800

--- a/src/lib/components/recal/elements/search/SearchBar.svelte
+++ b/src/lib/components/recal/elements/search/SearchBar.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-import settingsIcon from "$lib/img/icons/settingsicon.svg";
 import { modalStore } from "$lib/stores/modal";
 import { searchSettings, searchResults, searchCourseData, currentSchedule, isResult, hoveredCourse, research, ready } from "$lib/stores/recal";
 import { currentTerm } from "$lib/changeme";
@@ -7,6 +6,7 @@ import { rMeta } from "$lib/stores/rmeta";
 import { sectionData } from "$lib/stores/rsections";
 import { toastStore } from "$lib/stores/toast";
 import type { SupabaseClient } from "@supabase/supabase-js";
+import { calColors, calculateCssVars } from "$lib/stores/styles";
 
 export let supabase: SupabaseClient;
 
@@ -38,9 +38,22 @@ const triggerSearch = () => {
         for (let i = 0; i < $searchResults.length; i++)
             sectionData.add(supabase, $currentTerm, $searchResults[i].id);
 }
+
+$: cssVarStyles = calculateCssVars("2", $calColors);
 </script>
 
-<div>
+<div class="flex flex-col gap-2" style={cssVarStyles}>
+    <div class="h-4 text-xs w-full
+    flex justify-between gap-1 items-center">
+        <button class="flex-1 h-full
+        {$searchSettings.filters["Show All"].enabled ? "enabled" : "disabled"}">
+            Show All
+        </button>
+        <button class="flex-1 h-full
+        {$searchSettings.filters["Does Not Conflict"].enabled ? "enabled" : "disabled"}">
+            No Conflicts
+        </button>
+    </div>
     <div class="flex gap-2">
         <input type="text" placeholder="Search" 
         class="search-input std-area rounded-md" bind:this={inputBar}
@@ -73,4 +86,16 @@ const triggerSearch = () => {
     @apply text-zinc-600 dark:text-zinc-300 duration-150;
 }
 
+.enabled {
+    background-color: var(--bg);
+    color: var(--text);
+}
+
+.disabled {
+    @apply bg-zinc-200 dark:bg-zinc-700;
+}
+
+.disabled:hover {
+    @apply bg-zinc-300 dark:bg-zinc-600 duration-150;
+}
 </style>

--- a/src/lib/components/recal/elements/search/SearchBar.svelte
+++ b/src/lib/components/recal/elements/search/SearchBar.svelte
@@ -95,7 +95,8 @@ $: cssVarStyles = calculateCssVars("2", $calColors);
 }
 
 .togglebutton {
-    @apply flex-1 h-full rounded-sm duration-100;
+    @apply flex-1 h-full rounded-sm duration-100 text-zinc-900
+    dark:text-zinc-100;
 }
 
 .enabled {

--- a/src/lib/components/recal/elements/search/SearchBar.svelte
+++ b/src/lib/components/recal/elements/search/SearchBar.svelte
@@ -45,12 +45,20 @@ $: cssVarStyles = calculateCssVars("2", $calColors);
 <div class="flex flex-col gap-1" style={cssVarStyles}>
     <div class="h-4 text-xs w-full
     flex justify-between gap-1 items-center">
-        <button class="flex-1 h-full rounded-sm
-        {$searchSettings.filters["Show All"].enabled ? "enabled" : "disabled"}">
+        <button class="togglebutton
+        {$searchSettings.filters["Show All"].enabled ? "enabled" : "disabled"}"
+        on:click={() => 
+            $searchSettings.filters["Show All"].enabled = 
+            !$searchSettings.filters["Show All"].enabled
+        }>
             Show All
         </button>
-        <button class="flex-1 h-full rounded-sm
-        {$searchSettings.filters["Does Not Conflict"].enabled ? "enabled" : "disabled"}">
+        <button class="togglebutton
+        {$searchSettings.filters["Does Not Conflict"].enabled ? "enabled" : "disabled"}"
+        on:click={() => 
+            $searchSettings.filters["Does Not Conflict"].enabled = 
+            !$searchSettings.filters["Does Not Conflict"].enabled
+        }>
             No Conflicts
         </button>
     </div>
@@ -86,6 +94,10 @@ $: cssVarStyles = calculateCssVars("2", $calColors);
     @apply text-zinc-600 dark:text-zinc-300 duration-150;
 }
 
+.togglebutton {
+    @apply flex-1 h-full rounded-sm duration-100;
+}
+
 .enabled {
     background-color: var(--bg);
     color: var(--text);
@@ -96,6 +108,6 @@ $: cssVarStyles = calculateCssVars("2", $calColors);
 }
 
 .disabled:hover {
-    @apply bg-zinc-300 dark:bg-zinc-600 duration-150;
+    @apply bg-zinc-300 dark:bg-zinc-600;
 }
 </style>

--- a/src/lib/components/recal/elements/search/SearchBar.svelte
+++ b/src/lib/components/recal/elements/search/SearchBar.svelte
@@ -54,10 +54,10 @@ $: cssVarStyles = calculateCssVars("2", $calColors);
             Show All
         </button>
         <button class="togglebutton
-        {$searchSettings.filters["Does Not Conflict"].enabled ? "enabled" : "disabled"}"
+        {$searchSettings.filters["No Conflicts"].enabled ? "enabled" : "disabled"}"
         on:click={() => 
-            $searchSettings.filters["Does Not Conflict"].enabled = 
-            !$searchSettings.filters["Does Not Conflict"].enabled
+            $searchSettings.filters["No Conflicts"].enabled = 
+            !$searchSettings.filters["No Conflicts"].enabled
         }>
             No Conflicts
         </button>

--- a/src/lib/components/recal/elements/search/SearchBar.svelte
+++ b/src/lib/components/recal/elements/search/SearchBar.svelte
@@ -42,14 +42,14 @@ const triggerSearch = () => {
 $: cssVarStyles = calculateCssVars("2", $calColors);
 </script>
 
-<div class="flex flex-col gap-2" style={cssVarStyles}>
+<div class="flex flex-col gap-1" style={cssVarStyles}>
     <div class="h-4 text-xs w-full
     flex justify-between gap-1 items-center">
-        <button class="flex-1 h-full
+        <button class="flex-1 h-full rounded-sm
         {$searchSettings.filters["Show All"].enabled ? "enabled" : "disabled"}">
             Show All
         </button>
-        <button class="flex-1 h-full
+        <button class="flex-1 h-full rounded-sm
         {$searchSettings.filters["Does Not Conflict"].enabled ? "enabled" : "disabled"}">
             No Conflicts
         </button>

--- a/src/lib/components/recal/modals/AdvancedSearch.svelte
+++ b/src/lib/components/recal/modals/AdvancedSearch.svelte
@@ -75,8 +75,8 @@ const resetSearchSettings = () => {
                         <div class="border-slate-600/30 mx-8 p-2
                         dark:border-slate-200/30 border-t-2 mt-2">
                             <div>
-                                {#if filter === "Does Not Conflict"}
-                                <h3 class="text-lg font-semibold">Does Not Conflict</h3>
+                                {#if filter === "No Conflicts"}
+                                <h3 class="text-lg font-semibold">No Conflicts</h3>
                                 <p class="italic mb-2">
                                     "Only Available Sections" displays 
                                     only courses that have at least 1 section of
@@ -97,7 +97,7 @@ const resetSearchSettings = () => {
 
                             </div>
                             <!-- All and None Buttons-->
-                            {#if filter !== "Does Not Conflict"}
+                            {#if filter !== "No Conflicts"}
                             <div class="flex gap-2 mt-4">
                                 <StdButton message="Check All" 
                                 onClick={() => {

--- a/src/lib/stores/recal.ts
+++ b/src/lib/stores/recal.ts
@@ -133,7 +133,7 @@ export const searchResults = {
         }
 
         // * Does Not Conflict
-        if (settings.filters["Does Not Conflict"].enabled) {
+        if (settings.filters["No Conflicts"].enabled) {
             // Fetch all sections for all courses in term
             let termSec = get(sectionData)[term];
 
@@ -229,7 +229,7 @@ export const searchResults = {
                 // Check if any conflicts and filter
                 data = data.filter(x => !doesConflict(x, 
                     conflictList, 
-                    settings.filters["Does Not Conflict"]
+                    settings.filters["No Conflicts"]
                         .values["Only Available Sections"]));
 
             } // ! End of if (saved && meta)
@@ -507,7 +507,7 @@ export const DEFAULT_SETTINGS: SearchSettings = {
         "No Cancelled": {
             "enabled": false,
         },
-        "Does Not Conflict": {
+        "No Conflicts": {
             "enabled": false,
             "values": {
                 "Only Available Sections": false,


### PR DESCRIPTION
Add 2 toggle buttons above the search bar for "show all" and "no conflicts." The "show all" feature was a little bit unclear, and would require clicking through the advanced search settings to figure out what it does, and since I couldn't come up with a better descriptive name for it, I decided to add this button, hoping that people will click it and figure out what it does through discoverability. Just to make the space more well used, the "no conflicts" button is also there since that is probably the most important feature of the app. 